### PR TITLE
fix(vercel): removed verce.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "buildCommand": "npm run build:core && npm run build:demonextjs",
-  "outputDirectory": "packages/demo-nextjs/.next"
-}


### PR DESCRIPTION
Removed because each build on Vercel is configured via vercel.json. We have 3-4 demos (React, Next.js, Next.js with Contentful), so we need separate files like vercel1.json, vercel2.json, etc.